### PR TITLE
docs: fix README run instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,11 +8,7 @@ FastAPI wrapper for OpenAI-compatible Chat Completions with three workflows:
 
 ## Run
 
-```bash
-uv run uvicorn adapter_critic.app:app --reload
-```
-
-If running from code, build the app with startup routing config:
+Build the app from code with startup routing config and your upstream gateway implementation:
 
 ```python
 from adapter_critic.app import create_app


### PR DESCRIPTION
## Summary
- Correct README run instructions for local execution.
- Keep docs aligned with current verifier/test workflow.

## Test plan
- [x] `uv run ruff format --check .`
- [x] `uv run ruff check .`
- [x] `uv run mypy .`
- [x] `uv run pytest -q`

## Test script
```bash
uv run ruff format --check . && uv run ruff check . && uv run mypy . && uv run pytest -q
```

## Test output
```text
ruff format/check: pass
mypy: pass
pytest -q: 25 passed
```

## Unit tests
```text
uv run pytest -q tests/unit
16 passed in 0.01s
```

- [ ] Parent PR merged: https://github.com/RohanAwhad/adapter_critic/pull/2