### PR TITLE
chore: record DoD and ignore logs artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ __pycache__/
 *.pyc
 .pytest_cache/
 .mypy_cache/
+logs/

--- a/plans/CHECKLIST.md
+++ b/plans/CHECKLIST.md
@@ -1,17 +1,17 @@
 # Definition of Done Checklist
 
-- [ ] `POST /v1/chat/completions` works for direct mode.
-- [ ] Adapter mode implements API -> Adapter with search/replace (`lgtm` or edits).
-- [ ] Critic mode implements API -> Critic -> API sandwich.
-- [ ] Startup model-id routing config works without request overrides.
-- [ ] Request-level `extra_body.x_adapter_critic` overrides mode/model/base-url as planned.
-- [ ] Response includes intermediate stage outputs in `adapter_critic.intermediate`.
-- [ ] Response includes per-stage and total tokens in `adapter_critic.tokens`.
-- [ ] Unit tests cover contracts, edits, config resolution, and token aggregation.
-- [ ] Behavior tests cover direct/adapter/critic flow and routing/override behavior.
-- [ ] `ruff format` + `ruff` + `mypy` + `pytest` wired in pre-commit (line length 120).
-- [ ] README documents startup config and direct/adapter/critic usage examples.
-- [ ] `devlogs.md` maintained with per-iteration + verifier entries and checkpoint hashes.
-- [ ] `plans/HUMAN_COMMENTS.md` checked regularly and each check logged in `devlogs.md`.
-- [ ] Stacked-diff branch chain is maintained with one PR per branch and remote push done.
-- [ ] Non-first PRs include parent-merge checkbox and follow required PR format.
+- [x] `POST /v1/chat/completions` works for direct mode.
+- [x] Adapter mode implements API -> Adapter with search/replace (`lgtm` or edits).
+- [x] Critic mode implements API -> Critic -> API sandwich.
+- [x] Startup model-id routing config works without request overrides.
+- [x] Request-level `extra_body.x_adapter_critic` overrides mode/model/base-url as planned.
+- [x] Response includes intermediate stage outputs in `adapter_critic.intermediate`.
+- [x] Response includes per-stage and total tokens in `adapter_critic.tokens`.
+- [x] Unit tests cover contracts, edits, config resolution, and token aggregation.
+- [x] Behavior tests cover direct/adapter/critic flow and routing/override behavior.
+- [x] `ruff format` + `ruff` + `mypy` + `pytest` wired in pre-commit (line length 120).
+- [x] README documents startup config and direct/adapter/critic usage examples.
+- [x] `devlogs.md` maintained with per-iteration + verifier entries and checkpoint hashes.
+- [x] `plans/HUMAN_COMMENTS.md` checked regularly and each check logged in `devlogs.md`.
+- [x] Stacked-diff branch chain is maintained with one PR per branch and remote push done.
+- [x] Non-first PRs include parent-merge checkbox and follow required PR format.


### PR DESCRIPTION
## Summary
- Check off completed Definition-of-Done items in plan artifacts.
- Ignore `logs/` runtime artifacts to keep working tree clean.

## Test plan
- [x] `uv run ruff format --check .`
- [x] `uv run ruff check .`
- [x] `uv run mypy .`
- [x] `uv run pytest -q tests/unit`
- [x] `uv run pytest -q tests/behavior`
- [x] `uv run pytest -q`

## Test script
```bash
uv run ruff format --check . && \\
uv run ruff check . && \\
uv run mypy . && \\
uv run pytest -q tests/unit && \\
uv run pytest -q tests/behavior && \\
uv run pytest -q
```

## Test output
```text
ruff format/check: pass
mypy: pass
tests/unit: 16 passed
tests/behavior: 9 passed
pytest -q: 25 passed
```

## Unit tests
```text
uv run pytest -q tests/unit
16 passed in 0.01s
```

- [ ] Parent PR merged: https://github.com/RohanAwhad/adapter_critic/pull/3