### PR TITLE
feat: expose API draft tool calls in adapter telemetry

### DIFF
--- a/src/adapter_critic/workflows/adapter.py
+++ b/src/adapter_critic/workflows/adapter.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 from copy import deepcopy
 from typing import Any
 
@@ -170,6 +171,10 @@ async def run_adapter(
         "adapter": adapter_output,
         "final": final_text,
     }
+    if api_tool_calls is not None:
+        intermediate["api_draft_tool_calls"] = json.dumps(api_tool_calls, sort_keys=True)
+    if api_function_call is not None:
+        intermediate["api_draft_function_call"] = json.dumps(api_function_call, sort_keys=True)
     if not accepted_candidate and adapter_rejection_reason is not None:
         intermediate["adapter_rejection_reason"] = adapter_rejection_reason
 


### PR DESCRIPTION
## Summary
- Surface API-draft tool call/function-call payloads in `adapter_critic.intermediate` so tool calls are inspectable in served-adapter traces.
- Keep existing `api_draft`/`adapter`/`final` fields unchanged, while adding JSON-string fields only when call payloads are present.
- Add behavioral coverage proving tool calls from API draft are visible in intermediate telemetry.

## Test plan
- [x] Red: `uv run pytest -q tests/behavior/test_adapter_mode.py -k api_draft_tool_calls` (failed before patch)
- [x] Green: `uv run pytest -q tests/behavior/test_adapter_mode.py -k api_draft_tool_calls`
- [x] `uv run pytest -q tests/behavior/test_adapter_mode.py tests/behavior/test_response_telemetry.py tests/behavior/test_tool_passthrough.py`
- [x] `uv run ruff format --check . && uv run ruff check . && uv run mypy . && uv run pytest -q`


---
## Merge Order
- [x] Is PR #5 merged?