### PR TITLE
feat: remove deprecated function_call support across pipeline

### DIFF
--- a/experiments/v1/adapter_system_prompt.txt
+++ b/experiments/v1/adapter_system_prompt.txt
@@ -31,9 +31,6 @@ Rules for output format
 Allowed patch paths
 - /content
 - /tool_calls
-- /function_call
-- /function_call/name
-- /function_call/arguments
 - /tool_calls/{index}/function/name
 - /tool_calls/{index}/function/arguments
 
@@ -72,15 +69,6 @@ How-to examples
   "patches":[
     {"op":"replace","path":"/content","value":"I need your email to verify your identity first."},
     {"op":"replace","path":"/tool_calls","value":[]}
-  ]
-}
-
-5) Edit legacy function_call fields
-{
-  "decision":"patch",
-  "patches":[
-    {"op":"replace","path":"/function_call/name","value":"issue_credit"},
-    {"op":"replace","path":"/function_call/arguments","value":"{\"user_id\":\"user_123\",\"amount\":25}"}
   ]
 }
 

--- a/src/adapter_critic/app.py
+++ b/src/adapter_critic/app.py
@@ -121,7 +121,6 @@ def create_app(
             response_id=runtime_state.id_provider(),
             created=runtime_state.time_provider(),
             final_tool_calls=workflow_output.final_tool_calls,
-            final_function_call=workflow_output.final_function_call,
             finish_reason=workflow_output.finish_reason,
         )
 

--- a/src/adapter_critic/http_gateway.py
+++ b/src/adapter_critic/http_gateway.py
@@ -166,21 +166,6 @@ class OpenAICompatibleHttpGateway:
                 response_body=data,
             )
 
-        function_call_value = message.get("function_call")
-        if function_call_value is None:
-            function_call: dict[str, Any] | None = None
-        elif isinstance(function_call_value, dict):
-            function_call = function_call_value
-        else:
-            raise UpstreamResponseFormatError(
-                reason="choices[0].message.function_call is not an object",
-                model=model,
-                base_url=base_url,
-                message_count=len(messages),
-                status_code=response.status_code,
-                response_body=data,
-            )
-
         raw_usage = data.get("usage", {})
         usage = raw_usage if isinstance(raw_usage, dict) else {}
         content_value = message.get("content")
@@ -193,7 +178,7 @@ class OpenAICompatibleHttpGateway:
         else:
             content = ""
 
-        if content == "" and tool_calls is None and function_call is None:
+        if content == "" and tool_calls is None:
             raise UpstreamResponseFormatError(
                 reason="assistant message has empty content and no tool calls",
                 model=model,
@@ -214,6 +199,5 @@ class OpenAICompatibleHttpGateway:
                 total_tokens=int(usage.get("total_tokens", 0)),
             ),
             tool_calls=tool_calls,
-            function_call=function_call,
             finish_reason=finish_reason,
         )

--- a/src/adapter_critic/prompts.py
+++ b/src/adapter_critic/prompts.py
@@ -9,7 +9,7 @@ ADAPTER_SYSTEM_PROMPT = (
     "You are a response editor running in JSON mode. Respond with valid JSON only. "
     'Return {"decision":"lgtm"} if the draft is good, or return '
     '{"decision":"patch","patches":[{"op":"replace","path":"/content","value":"..."}]} '
-    "to apply RFC6902-style replace patches. Never emit tool calls or function_call in your own output."
+    "to apply RFC6902-style replace patches. Never emit tool calls in your own output."
 )
 
 ADAPTER_RESPONSE_FORMAT: dict[str, Any] = {
@@ -68,10 +68,6 @@ def _render_tool_contract(request_options: dict[str, Any] | None) -> str | None:
     tool_choice = request_options.get("tool_choice")
     if tool_choice is not None:
         contract["tool_choice"] = tool_choice
-
-    function_call = request_options.get("function_call")
-    if function_call is not None:
-        contract["function_call"] = function_call
 
     if len(contract) == 0:
         return None

--- a/src/adapter_critic/response_builder.py
+++ b/src/adapter_critic/response_builder.py
@@ -17,22 +17,17 @@ def build_response(
     response_id: str,
     created: int,
     final_tool_calls: list[dict[str, Any]] | None = None,
-    final_function_call: dict[str, Any] | None = None,
     finish_reason: str = "stop",
 ) -> dict[str, Any]:
     normalized_tool_calls = normalize_tool_calls(final_tool_calls)
-    response_function_call = final_function_call if normalized_tool_calls is None else None
     response_finish_reason = infer_finish_reason(
         finish_reason,
         tool_calls=normalized_tool_calls,
-        function_call=response_function_call,
     )
 
     message: dict[str, Any] = {"role": "assistant", "content": final_text}
     if normalized_tool_calls is not None:
         message["tool_calls"] = normalized_tool_calls
-    if response_function_call is not None:
-        message["function_call"] = response_function_call
 
     return {
         "id": response_id,

--- a/src/adapter_critic/response_shape.py
+++ b/src/adapter_critic/response_shape.py
@@ -42,25 +42,14 @@ def has_valid_tool_calls(tool_calls: list[dict[str, Any]] | None) -> bool:
     return True
 
 
-def has_valid_function_call(function_call: dict[str, Any] | None) -> bool:
-    if function_call is None:
-        return True
-    name = function_call.get("name")
-    arguments = function_call.get("arguments")
-    return isinstance(name, str) and isinstance(arguments, str) and _is_json_object_string(arguments)
-
-
 def infer_finish_reason(
     raw_finish_reason: str,
     *,
     tool_calls: list[dict[str, Any]] | None,
-    function_call: dict[str, Any] | None,
 ) -> str:
     normalized_tool_calls = normalize_tool_calls(tool_calls)
     if normalized_tool_calls is not None:
         return "tool_calls"
-    if function_call is not None:
-        return "function_call"
     if raw_finish_reason in {"length", "content_filter"}:
         return raw_finish_reason
     return "stop"

--- a/src/adapter_critic/upstream.py
+++ b/src/adapter_critic/upstream.py
@@ -17,7 +17,6 @@ class UpstreamResult(BaseModel):
     content: str
     usage: TokenUsage
     tool_calls: list[dict[str, Any]] | None = None
-    function_call: dict[str, Any] | None = None
     finish_reason: str = "stop"
 
 

--- a/src/adapter_critic/workflows/adapter.py
+++ b/src/adapter_critic/workflows/adapter.py
@@ -8,12 +8,7 @@ from ..config import RuntimeConfig
 from ..contracts import ChatMessage
 from ..edits import apply_adapter_output_to_draft, build_adapter_draft_payload
 from ..prompts import ADAPTER_RESPONSE_FORMAT, build_adapter_messages
-from ..response_shape import (
-    has_valid_function_call,
-    has_valid_tool_calls,
-    infer_finish_reason,
-    normalize_tool_calls,
-)
+from ..response_shape import has_valid_tool_calls, infer_finish_reason, normalize_tool_calls
 from ..upstream import TokenUsage, UpstreamGateway
 from .direct import WorkflowOutput
 
@@ -26,43 +21,20 @@ def _add_usage(total: TokenUsage, current: TokenUsage) -> TokenUsage:
     )
 
 
-def _is_adapter_candidate_usable(
-    *,
-    content: str,
-    tool_calls: list[dict[str, Any]] | None,
-    function_call: dict[str, Any] | None,
-    require_call: bool,
-) -> bool:
-    return (
-        _adapter_candidate_rejection_reason(
-            content=content,
-            tool_calls=tool_calls,
-            function_call=function_call,
-            require_call=require_call,
-        )
-        is None
-    )
-
-
 def _adapter_candidate_rejection_reason(
     *,
     content: str,
     tool_calls: list[dict[str, Any]] | None,
-    function_call: dict[str, Any] | None,
     require_call: bool,
 ) -> str | None:
     normalized_tool_calls = normalize_tool_calls(tool_calls)
-    has_call = normalized_tool_calls is not None or function_call is not None
+    has_call = normalized_tool_calls is not None
     if normalized_tool_calls is not None and not has_valid_tool_calls(normalized_tool_calls):
         return "tool_calls must have OpenAI function shape with JSON-object arguments"
-    if function_call is not None and not has_valid_function_call(function_call):
-        return "function_call must include string name and JSON-object arguments"
-    if normalized_tool_calls is not None and function_call is not None:
-        return "tool_calls and function_call cannot both be present"
     if content == "" and not has_call:
         return "assistant message has empty content and no calls"
     if require_call and not has_call:
-        return "request requires a tool/function call"
+        return "request requires a tool call"
     return None
 
 
@@ -72,9 +44,7 @@ def _requires_tool_call(request_options: dict[str, Any]) -> bool:
         return True
     if isinstance(tool_choice, dict):
         return tool_choice.get("type") == "function"
-
-    function_call = request_options.get("function_call")
-    return bool(isinstance(function_call, dict))
+    return False
 
 
 async def run_adapter(
@@ -94,13 +64,11 @@ async def run_adapter(
         request_options=request_options,
     )
     api_tool_calls = normalize_tool_calls(api_draft.tool_calls)
-    api_function_call = api_draft.function_call if api_tool_calls is None else None
     requested_requires_call = _requires_tool_call(request_options)
 
     draft_payload = build_adapter_draft_payload(
         content=api_draft.content,
         tool_calls=api_tool_calls,
-        function_call=api_function_call,
     )
 
     adapter_messages = build_adapter_messages(
@@ -116,7 +84,6 @@ async def run_adapter(
 
     final_text = api_draft.content
     final_tool_calls = api_tool_calls
-    final_function_call = api_function_call
     accepted_candidate = False
 
     max_attempts = runtime.max_adapter_retries + 1
@@ -131,10 +98,9 @@ async def run_adapter(
         adapter_usage = _add_usage(adapter_usage, adapter_review.usage)
         adapter_output = adapter_review.content
         try:
-            candidate_text, candidate_tool_calls, candidate_function_call = apply_adapter_output_to_draft(
+            candidate_text, candidate_tool_calls = apply_adapter_output_to_draft(
                 content=api_draft.content,
                 tool_calls=api_tool_calls,
-                function_call=api_function_call,
                 adapter_output=adapter_review.content,
             )
         except ValueError as exc:
@@ -142,11 +108,9 @@ async def run_adapter(
             continue
 
         candidate_tool_calls = normalize_tool_calls(candidate_tool_calls)
-        candidate_function_call = candidate_function_call if candidate_tool_calls is None else None
         rejection_reason = _adapter_candidate_rejection_reason(
             content=candidate_text,
             tool_calls=candidate_tool_calls,
-            function_call=candidate_function_call,
             require_call=requested_requires_call,
         )
         if rejection_reason is not None:
@@ -155,7 +119,6 @@ async def run_adapter(
 
         final_text = candidate_text
         final_tool_calls = candidate_tool_calls
-        final_function_call = candidate_function_call
         accepted_candidate = True
         adapter_rejection_reason = None
         break
@@ -163,7 +126,6 @@ async def run_adapter(
     finish_reason = infer_finish_reason(
         "stop",
         tool_calls=final_tool_calls,
-        function_call=final_function_call,
     )
 
     intermediate = {
@@ -173,8 +135,6 @@ async def run_adapter(
     }
     if api_tool_calls is not None:
         intermediate["api_draft_tool_calls"] = json.dumps(api_tool_calls, sort_keys=True)
-    if api_function_call is not None:
-        intermediate["api_draft_function_call"] = json.dumps(api_function_call, sort_keys=True)
     if not accepted_candidate and adapter_rejection_reason is not None:
         intermediate["adapter_rejection_reason"] = adapter_rejection_reason
 
@@ -183,6 +143,5 @@ async def run_adapter(
         intermediate=intermediate,
         stage_usage={"api": api_draft.usage, "adapter": adapter_usage},
         final_tool_calls=final_tool_calls,
-        final_function_call=final_function_call,
         finish_reason=finish_reason,
     )

--- a/src/adapter_critic/workflows/critic.py
+++ b/src/adapter_critic/workflows/critic.py
@@ -39,12 +39,10 @@ async def run_critic(
         request_options=request_options,
     )
     api_tool_calls = normalize_tool_calls(api_draft.tool_calls)
-    api_function_call = api_draft.function_call if api_tool_calls is None else None
 
     draft_payload = build_adapter_draft_payload(
         content=api_draft.content,
         tool_calls=api_tool_calls,
-        function_call=api_function_call,
     )
 
     critic_messages = build_critic_messages(
@@ -79,8 +77,6 @@ async def run_critic(
     }
     if api_tool_calls is not None:
         intermediate["api_draft_tool_calls"] = json.dumps(api_tool_calls, sort_keys=True)
-    if api_function_call is not None:
-        intermediate["api_draft_function_call"] = json.dumps(api_function_call, sort_keys=True)
 
     return WorkflowOutput(
         final_text=final_response.content,
@@ -91,6 +87,5 @@ async def run_critic(
             "api_final": final_response.usage,
         },
         final_tool_calls=final_response.tool_calls,
-        final_function_call=final_response.function_call,
         finish_reason=final_response.finish_reason,
     )

--- a/src/adapter_critic/workflows/direct.py
+++ b/src/adapter_critic/workflows/direct.py
@@ -14,7 +14,6 @@ class WorkflowOutput(BaseModel):
     intermediate: dict[str, str]
     stage_usage: dict[str, TokenUsage]
     final_tool_calls: list[dict[str, Any]] | None = None
-    final_function_call: dict[str, Any] | None = None
     finish_reason: str = "stop"
 
 
@@ -36,6 +35,5 @@ async def run_direct(
         intermediate={"api": response.content},
         stage_usage={"api": response.usage},
         final_tool_calls=response.tool_calls,
-        final_function_call=response.function_call,
         finish_reason=response.finish_reason,
     )

--- a/tests/unit/test_edits.py
+++ b/tests/unit/test_edits.py
@@ -2,10 +2,7 @@ from __future__ import annotations
 
 import pytest
 
-from adapter_critic.edits import (
-    apply_adapter_output,
-    apply_adapter_output_to_draft,
-)
+from adapter_critic.edits import apply_adapter_output, apply_adapter_output_to_draft
 
 
 def test_lgtm_returns_original_draft() -> None:
@@ -17,27 +14,6 @@ def test_single_replace_patch_updates_content() -> None:
     draft = "hello world"
     edits = '{"decision":"patch","patches":[{"op":"replace","path":"/content","value":"hello universe"}]}'
     assert apply_adapter_output(draft, edits) == "hello universe"
-
-
-def test_patch_can_update_content_and_function_call() -> None:
-    final_text, final_tool_calls, final_function_call = apply_adapter_output_to_draft(
-        content="Draft answer",
-        tool_calls=None,
-        function_call={"name": "transfer_to_human", "arguments": "{}"},
-        adapter_output=(
-            '{"decision":"patch","patches":['
-            '{"op":"replace","path":"/content","value":"Final answer"},'
-            '{"op":"replace","path":"/function_call/arguments","value":"{\\"reason\\":\\"user_requested\\"}"}'
-            "]}"
-        ),
-    )
-
-    assert final_text == "Final answer"
-    assert final_tool_calls is None
-    assert final_function_call == {
-        "name": "transfer_to_human",
-        "arguments": '{"reason":"user_requested"}',
-    }
 
 
 def test_invalid_json_raises_error() -> None:
@@ -75,10 +51,7 @@ def test_tool_call_id_path_is_disallowed() -> None:
                     },
                 }
             ],
-            function_call=None,
-            adapter_output=(
-                '{"decision":"patch","patches":[{"op":"replace","path":"/tool_calls/0/id","value":"call_new"}]}'
-            ),
+            adapter_output='{"decision":"patch","patches":[{"op":"replace","path":"/tool_calls/0/id","value":"call_new"}]}',
         )
 
 
@@ -96,10 +69,7 @@ def test_tool_call_type_path_is_disallowed() -> None:
                     },
                 }
             ],
-            function_call=None,
-            adapter_output=(
-                '{"decision":"patch","patches":[{"op":"replace","path":"/tool_calls/0/type","value":"non_function"}]}'
-            ),
+            adapter_output='{"decision":"patch","patches":[{"op":"replace","path":"/tool_calls/0/type","value":"non_function"}]}',
         )
 
 
@@ -117,7 +87,6 @@ def test_out_of_range_tool_call_index_raises_error() -> None:
                     },
                 }
             ],
-            function_call=None,
             adapter_output=(
                 '{"decision":"patch","patches":['
                 '{"op":"replace","path":"/tool_calls/2/function/arguments","value":"{\\"reservation_id\\":\\"EHGLP3\\"}"}'
@@ -127,7 +96,7 @@ def test_out_of_range_tool_call_index_raises_error() -> None:
 
 
 def test_apply_adapter_output_to_draft_can_edit_tool_call_arguments() -> None:
-    final_text, final_tool_calls, final_function_call = apply_adapter_output_to_draft(
+    final_text, final_tool_calls = apply_adapter_output_to_draft(
         content="",
         tool_calls=[
             {
@@ -139,7 +108,6 @@ def test_apply_adapter_output_to_draft_can_edit_tool_call_arguments() -> None:
                 },
             }
         ],
-        function_call=None,
         adapter_output=(
             '{"decision":"patch","patches":['
             '{"op":"replace","path":"/tool_calls/0/function/arguments","value":"{\\"reservation_id\\":\\"EHGLP3\\"}"}'
@@ -148,7 +116,6 @@ def test_apply_adapter_output_to_draft_can_edit_tool_call_arguments() -> None:
     )
 
     assert final_text == ""
-    assert final_function_call is None
     assert final_tool_calls is not None
     assert final_tool_calls[0]["function"]["arguments"] == '{"reservation_id":"EHGLP3"}'
 

--- a/tests/unit/test_response_schema.py
+++ b/tests/unit/test_response_schema.py
@@ -97,4 +97,3 @@ def test_response_normalizes_empty_tool_calls_to_stop() -> None:
     choice = response["choices"][0]
     assert choice["finish_reason"] == "stop"
     assert "tool_calls" not in choice["message"]
-

--- a/tests/unit/test_response_schema.py
+++ b/tests/unit/test_response_schema.py
@@ -98,38 +98,3 @@ def test_response_normalizes_empty_tool_calls_to_stop() -> None:
     assert choice["finish_reason"] == "stop"
     assert "tool_calls" not in choice["message"]
 
-
-def test_response_drops_function_call_when_tool_calls_exist() -> None:
-    request = ChatCompletionRequest.model_validate(
-        {
-            "model": "served-direct",
-            "messages": [{"role": "user", "content": "hello"}],
-        }
-    )
-    tokens = TokenBreakdown(
-        stages={"api": TokenUsage(prompt_tokens=1, completion_tokens=2, total_tokens=3)},
-        total=TokenUsage(prompt_tokens=1, completion_tokens=2, total_tokens=3),
-    )
-    response = build_response(
-        request,
-        mode="direct",
-        final_text="",
-        intermediate={"api": ""},
-        tokens=tokens,
-        response_id="chatcmpl-fixed",
-        created=1700000000,
-        finish_reason="tool_calls",
-        final_tool_calls=[
-            {
-                "id": "call_cancel",
-                "type": "function",
-                "function": {"name": "cancel_reservation", "arguments": '{"reservation_id":"EHGLP3"}'},
-            }
-        ],
-        final_function_call={"response": "YOU ARE BEING TRANSFERRED TO A HUMAN AGENT. PLEASE HOLD ON."},
-    )
-
-    choice = response["choices"][0]
-    assert choice["finish_reason"] == "tool_calls"
-    assert choice["message"]["tool_calls"][0]["function"]["name"] == "cancel_reservation"
-    assert "function_call" not in choice["message"]

--- a/tests/unit/test_response_shape.py
+++ b/tests/unit/test_response_shape.py
@@ -1,11 +1,6 @@
 from __future__ import annotations
 
-from adapter_critic.response_shape import (
-    has_valid_function_call,
-    has_valid_tool_calls,
-    infer_finish_reason,
-    normalize_tool_calls,
-)
+from adapter_critic.response_shape import has_valid_tool_calls, infer_finish_reason, normalize_tool_calls
 
 
 def test_normalize_tool_calls_empty_list_to_none() -> None:
@@ -77,11 +72,6 @@ def test_has_valid_tool_calls_requires_arguments_json_object() -> None:
     )
 
 
-def test_has_valid_function_call_requires_name_and_arguments_strings() -> None:
-    assert has_valid_function_call({"name": "cancel_reservation", "arguments": '{"reservation_id":"EHGLP3"}'})
-    assert not has_valid_function_call({"name": "cancel_reservation", "arguments": None})
-
-
 def test_infer_finish_reason_uses_message_fields() -> None:
     assert (
         infer_finish_reason(
@@ -93,9 +83,8 @@ def test_infer_finish_reason_uses_message_fields() -> None:
                     "function": {"name": "cancel_reservation", "arguments": '{"reservation_id":"EHGLP3"}'},
                 }
             ],
-            function_call=None,
         )
         == "tool_calls"
     )
-    assert infer_finish_reason("tool_calls", tool_calls=[], function_call=None) == "stop"
-    assert infer_finish_reason("length", tool_calls=None, function_call=None) == "length"
+    assert infer_finish_reason("tool_calls", tool_calls=[]) == "stop"
+    assert infer_finish_reason("length", tool_calls=None) == "length"


### PR DESCRIPTION
### Motivation
- OpenAI and other providers deprecated the legacy `function_call` field in favor of modern `tool_calls`, so the pipeline should stop accepting/propagating `function_call` and operate on `tool_calls` only.

### Description
- Remove `function_call` from the upstream result model and HTTP gateway parsing/validation, and ensure upstream responses only populate `tool_calls` (see `src/adapter_critic/upstream.py` and `src/adapter_critic/http_gateway.py`).
- Simplify adapter draft payload and patch handling to only include `content` and `tool_calls` and remove `/function_call` paths from allowed patches (see `src/adapter_critic/edits.py`).
- Remove legacy `function_call` plumbing from response building, response shaping, and workflow outputs, and update adapter/critic/direct workflows to validate and operate on `tool_calls` only (see `src/adapter_critic/response_builder.py`, `src/adapter_critic/response_shape.py`, and `src/adapter_critic/workflows/*`).
- Update prompts, experiment text, and unit tests to reflect the tool-calls-only behavior (see `src/adapter_critic/prompts.py`, `experiments/adapter_prompt_v1/adapter_system_prompt.txt`, and tests under `tests/unit`).

### Testing
- Ran `pytest -q` and all unit/behavior tests passed: `78 passed`.
- Ran `ruff check .` and linting passed with no issues.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6998b33d2c648329bddc6cbc0440c96f)